### PR TITLE
Add support for media translation

### DIFF
--- a/src/class-wpml-cornerstone-integration-factory.php
+++ b/src/class-wpml-cornerstone-integration-factory.php
@@ -9,6 +9,7 @@ class WPML_Cornerstone_Integration_Factory {
 		$action_filter_loader->load(
 			array(
 				'WPML_PB_Cornerstone_Handle_Custom_Fields_Factory',
+				'WPML_Cornerstone_Media_Hooks_Factory',
 			)
 		);
 

--- a/src/media/class-wpml-cornerstone-media-hooks-factory.php
+++ b/src/media/class-wpml-cornerstone-media-hooks-factory.php
@@ -1,0 +1,10 @@
+<?php
+
+class WPML_Cornerstone_Media_Hooks_Factory implements IWPML_Backend_Action_Loader, IWPML_Frontend_Action_Loader {
+	public function create() {
+		return new WPML_Page_Builders_Media_Hooks(
+			new WPML_Cornerstone_Update_Media_Factory(),
+			WPML_Cornerstone_Integration_Factory::SLUG
+		);
+	}
+}

--- a/src/media/class-wpml-cornerstone-media-node-provider.php
+++ b/src/media/class-wpml-cornerstone-media-node-provider.php
@@ -1,0 +1,61 @@
+<?php
+
+class WPML_Cornerstone_Media_Node_Provider {
+
+	private $media_translate;
+
+	private $nodes = array();
+
+	public function __construct( WPML_Page_Builders_Media_Translate $media_translate ) {
+		$this->media_translate = $media_translate;
+	}
+
+	/**
+	 * @param string $type
+	 *
+	 * @return WPML_Cornerstone_Media_Node|null
+	 */
+	public function get( $type ) {
+		if ( ! array_key_exists( $type, $this->nodes ) ) {
+			$this->add( $type );
+		}
+
+		return $this->nodes[ $type ];
+	}
+
+	/**
+	 * @param string $type
+	 */
+	private function add( $type ) {
+		switch ( $type ) {
+			case 'image':
+				$node = new WPML_Cornerstone_Media_Node_Image( $this->media_translate );
+				break;
+
+			case 'classic:creative-cta':
+				$node = new WPML_Cornerstone_Media_Node_Classic_Creative_CTA( $this->media_translate );
+				break;
+
+			case 'classic:feature-box':
+				$node = new WPML_Cornerstone_Media_Node_Classic_Feature_Box( $this->media_translate );
+				break;
+
+			case 'classic:card':
+				$node = new WPML_Cornerstone_Media_Node_Classic_Card( $this->media_translate );
+				break;
+
+			case 'classic:image':
+				$node = new WPML_Cornerstone_Media_Node_Classic_Image( $this->media_translate );
+				break;
+
+			case 'classic:promo':
+				$node = new WPML_Cornerstone_Media_Node_Classic_Promo( $this->media_translate );
+				break;
+
+			default:
+				$node = null;
+		}
+
+		$this->nodes[ $type ] = $node;
+	}
+}

--- a/src/media/class-wpml-cornerstone-media-nodes-iterator.php
+++ b/src/media/class-wpml-cornerstone-media-nodes-iterator.php
@@ -1,0 +1,46 @@
+<?php
+
+class WPML_Cornerstone_Media_Nodes_Iterator implements IWPML_PB_Media_Nodes_Iterator {
+
+	/** @var WPML_Cornerstone_Media_Node_Provider $node_provider */
+	private $node_provider;
+	public function __construct( WPML_Cornerstone_Media_Node_Provider $node_provider ) {
+		$this->node_provider = $node_provider;
+	}
+
+	/**
+	 * @param array $data_array
+	 * @param string $lang
+	 * @param string $source_lang
+	 *
+	 * @return array
+	 */
+	public function translate( $data_array, $lang, $source_lang ) {
+		foreach ( $data_array as $key => &$data ) {
+			if ( isset( $data['_modules'] ) && $data['_modules'] ) {
+				$data['_modules'] = $this->translate( $data['_modules'], $lang, $source_lang );
+			} elseif ( is_numeric( $key ) && isset( $data['_type'] ) ) {
+				$data = $this->translate_node( $data, $lang, $source_lang );
+			}
+		}
+
+		return $data_array;
+	}
+
+	/**
+	 * @param stdClass $settings
+	 * @param string $lang
+	 * @param string $source_lang
+	 *
+	 * @return stdClass
+	 */
+	private function translate_node( $settings, $lang, $source_lang ) {
+		$node = $this->node_provider->get( $settings['_type'] );
+
+		if ( $node ) {
+			$settings = $node->translate( $settings, $lang, $source_lang );
+		}
+
+		return $settings;
+	}
+}

--- a/src/media/class-wpml-cornerstone-update-media-factory.php
+++ b/src/media/class-wpml-cornerstone-update-media-factory.php
@@ -1,0 +1,33 @@
+<?php
+
+class WPML_Cornerstone_Update_Media_Factory implements IWPML_PB_Media_Update_Factory {
+
+	/** @var WPML_Page_Builders_Media_Translate $media_translate */
+	private $media_translate;
+
+	public function create() {
+		global $sitepress;
+		return new WPML_Page_Builders_Update_Media(
+			new WPML_Page_Builders_Update( new WPML_Cornerstone_Data_Settings() ),
+			new WPML_Translation_Element_Factory( $sitepress ),
+			new WPML_Cornerstone_Media_Nodes_Iterator(
+				new WPML_Cornerstone_Media_Node_Provider( $this->get_media_translate() )
+			),
+			new WPML_Page_Builders_Media_Usage( $this->get_media_translate(), new WPML_Media_Usage_Factory() )
+		);
+	}
+
+	/** @return WPML_Page_Builders_Media_Translate */
+	private function get_media_translate() {
+		global $sitepress;
+
+		if ( ! $this->media_translate ) {
+			$this->media_translate = new WPML_Page_Builders_Media_Translate(
+				new WPML_Translation_Element_Factory( $sitepress ),
+				new WPML_Media_Image_Translate( $sitepress, new WPML_Media_Attachment_By_URL_Factory() )
+			);
+		}
+
+		return $this->media_translate;
+	}
+}

--- a/src/media/modules/abstract/class-wpml-cornerstone-media-node-with-urls.php
+++ b/src/media/modules/abstract/class-wpml-cornerstone-media-node-with-urls.php
@@ -1,0 +1,24 @@
+<?php
+
+abstract class WPML_Cornerstone_Media_Node_With_URLs extends WPML_Cornerstone_Media_Node {
+
+	/** @return array */
+	abstract protected function get_keys();
+
+	/**
+	 * @param array  $node_data
+	 * @param string $target_lang
+	 * @param string $source_lang
+	 *
+	 * @return array
+	 */
+	public function translate( $node_data, $target_lang, $source_lang ) {
+		foreach ( $this->get_keys() as $key ) {
+			if ( ! empty( $node_data[ $key ] ) ) {
+				$node_data[ $key ] = $this->media_translate->translate_image_url( $node_data[ $key ], $target_lang, $source_lang );
+			}
+		}
+
+		return $node_data;
+	}
+}

--- a/src/media/modules/abstract/class-wpml-cornerstone-media-node.php
+++ b/src/media/modules/abstract/class-wpml-cornerstone-media-node.php
@@ -1,0 +1,20 @@
+<?php
+
+abstract class WPML_Cornerstone_Media_Node {
+
+	/** @var WPML_Page_Builders_Media_Translate $media_translate */
+	protected $media_translate;
+
+	public function __construct( WPML_Page_Builders_Media_Translate $media_translate ) {
+		$this->media_translate = $media_translate;
+	}
+
+	/**
+	 * @param array  $node_data
+	 * @param string $target_lang
+	 * @param string $source_lang
+	 *
+	 * @return array
+	 */
+	abstract function translate( $node_data, $target_lang, $source_lang );
+}

--- a/src/media/modules/class-wpml-cornerstone-media-node-classic-card.php
+++ b/src/media/modules/class-wpml-cornerstone-media-node-classic-card.php
@@ -1,0 +1,10 @@
+<?php
+
+class WPML_Cornerstone_Media_Node_Classic_Card extends WPML_Cornerstone_Media_Node_With_URLs {
+
+	protected function get_keys() {
+		return array(
+			'front_image',
+		);
+	}
+}

--- a/src/media/modules/class-wpml-cornerstone-media-node-classic-creative-cta.php
+++ b/src/media/modules/class-wpml-cornerstone-media-node-classic-creative-cta.php
@@ -1,0 +1,10 @@
+<?php
+
+class WPML_Cornerstone_Media_Node_Classic_Creative_CTA extends WPML_Cornerstone_Media_Node_With_URLs {
+
+	protected function get_keys() {
+		return array(
+			'image',
+		);
+	}
+}

--- a/src/media/modules/class-wpml-cornerstone-media-node-classic-feature-box.php
+++ b/src/media/modules/class-wpml-cornerstone-media-node-classic-feature-box.php
@@ -1,0 +1,10 @@
+<?php
+
+class WPML_Cornerstone_Media_Node_Classic_Feature_Box extends WPML_Cornerstone_Media_Node_With_URLs {
+
+	protected function get_keys() {
+		return array(
+			'graphic_image',
+		);
+	}
+}

--- a/src/media/modules/class-wpml-cornerstone-media-node-classic-image.php
+++ b/src/media/modules/class-wpml-cornerstone-media-node-classic-image.php
@@ -1,0 +1,10 @@
+<?php
+
+class WPML_Cornerstone_Media_Node_Classic_Image extends WPML_Cornerstone_Media_Node_With_URLs {
+
+	protected function get_keys() {
+		return array(
+			'src',
+		);
+	}
+}

--- a/src/media/modules/class-wpml-cornerstone-media-node-classic-promo.php
+++ b/src/media/modules/class-wpml-cornerstone-media-node-classic-promo.php
@@ -1,0 +1,10 @@
+<?php
+
+class WPML_Cornerstone_Media_Node_Classic_Promo extends WPML_Cornerstone_Media_Node_With_URLs {
+
+	protected function get_keys() {
+		return array(
+			'image',
+		);
+	}
+}

--- a/src/media/modules/class-wpml-cornerstone-media-node-image.php
+++ b/src/media/modules/class-wpml-cornerstone-media-node-image.php
@@ -1,0 +1,10 @@
+<?php
+
+class WPML_Cornerstone_Media_Node_Image extends WPML_Cornerstone_Media_Node_With_URLs {
+
+	protected function get_keys() {
+		return array(
+			'image_src',
+		);
+	}
+}

--- a/tests/phpunit/tests/media/modules/test-wpml-cornerstone-media-node-classic-card.php
+++ b/tests/phpunit/tests/media/modules/test-wpml-cornerstone-media-node-classic-card.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * @group media
+ */
+class Test_WPML_Cornerstone_Media_Node_Classic_Card extends OTGS_TestCase {
+
+	/**
+	 * @test
+	 */
+	public function it_should_translate() {
+		$source_lang    = 'en';
+		$target_lang    = 'fr';
+		$original_url   = 'http://example.org/dog.jpg';
+		$translated_url = 'http://example.org/chien.jpg';
+
+		$settings = array(
+			'foo'         => 'bar',
+			'front_image' => $original_url,
+			'_type'       => 'classic:card',
+		);
+
+		$expected_settings = array(
+			'foo'         => 'bar',
+			'front_image' => $translated_url,
+			'_type'       => 'classic:card',
+		);
+
+		$media_translate = $this->getMockBuilder( 'WPML_Page_Builders_Media_Translate' )
+		                        ->disableOriginalConstructor()->getMock();
+		$media_translate->method( 'translate_image_url' )
+		                ->with( $original_url, $target_lang, $source_lang )
+		                ->willReturn( $translated_url );
+
+		$subject = new WPML_Cornerstone_Media_Node_Classic_Card( $media_translate );
+
+		$this->assertEquals( $expected_settings, $subject->translate( $settings, $target_lang, $source_lang ) );
+	}
+}

--- a/tests/phpunit/tests/media/modules/test-wpml-cornerstone-media-node-classic-creative-cta.php
+++ b/tests/phpunit/tests/media/modules/test-wpml-cornerstone-media-node-classic-creative-cta.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * @group media
+ */
+class Test_WPML_Cornerstone_Media_Node_Classic_Creative_CTA extends OTGS_TestCase {
+
+	/**
+	 * @test
+	 */
+	public function it_should_translate() {
+		$source_lang    = 'en';
+		$target_lang    = 'fr';
+		$original_url   = 'http://example.org/dog.jpg';
+		$translated_url = 'http://example.org/chien.jpg';
+
+		$settings = array(
+			'foo'   => 'bar',
+			'image' => $original_url,
+			'_type' => 'classic:creative-cta',
+		);
+
+		$expected_settings = array(
+			'foo'   => 'bar',
+			'image' => $translated_url,
+			'_type' => 'classic:creative-cta',
+		);
+
+		$media_translate = $this->getMockBuilder( 'WPML_Page_Builders_Media_Translate' )
+		                        ->disableOriginalConstructor()->getMock();
+		$media_translate->method( 'translate_image_url' )
+		                ->with( $original_url, $target_lang, $source_lang )
+		                ->willReturn( $translated_url );
+
+		$subject = new WPML_Cornerstone_Media_Node_Classic_Creative_CTA( $media_translate );
+
+		$this->assertEquals( $expected_settings, $subject->translate( $settings, $target_lang, $source_lang ) );
+	}
+}

--- a/tests/phpunit/tests/media/modules/test-wpml-cornerstone-media-node-classic-feature-box.php
+++ b/tests/phpunit/tests/media/modules/test-wpml-cornerstone-media-node-classic-feature-box.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * @group media
+ */
+class Test_WPML_Cornerstone_Media_Node_Classic_Feature_Box extends OTGS_TestCase {
+
+	/**
+	 * @test
+	 */
+	public function it_should_translate() {
+		$source_lang    = 'en';
+		$target_lang    = 'fr';
+		$original_url   = 'http://example.org/dog.jpg';
+		$translated_url = 'http://example.org/chien.jpg';
+
+		$settings = array(
+			'foo'           => 'bar',
+			'graphic_image' => $original_url,
+			'_type'         => 'classic:feature-box',
+		);
+
+		$expected_settings = array(
+			'foo'           => 'bar',
+			'graphic_image' => $translated_url,
+			'_type'         => 'classic:feature-box',
+		);
+
+		$media_translate = $this->getMockBuilder( 'WPML_Page_Builders_Media_Translate' )
+		                        ->disableOriginalConstructor()->getMock();
+		$media_translate->method( 'translate_image_url' )
+		                ->with( $original_url, $target_lang, $source_lang )
+		                ->willReturn( $translated_url );
+
+		$subject = new WPML_Cornerstone_Media_Node_Classic_Feature_Box( $media_translate );
+
+		$this->assertEquals( $expected_settings, $subject->translate( $settings, $target_lang, $source_lang ) );
+	}
+}

--- a/tests/phpunit/tests/media/modules/test-wpml-cornerstone-media-node-classic-image.php
+++ b/tests/phpunit/tests/media/modules/test-wpml-cornerstone-media-node-classic-image.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * @group media
+ */
+class Test_WPML_Cornerstone_Media_Node_Classic_Image extends OTGS_TestCase {
+
+	/**
+	 * @test
+	 */
+	public function it_should_translate() {
+		$source_lang    = 'en';
+		$target_lang    = 'fr';
+		$original_url   = 'http://example.org/dog.jpg';
+		$translated_url = 'http://example.org/chien.jpg';
+
+		$settings = array(
+			'foo'   => 'bar',
+			'src'   => $original_url,
+			'_type' => 'classic:image',
+		);
+
+		$expected_settings = array(
+			'foo'   => 'bar',
+			'src'   => $translated_url,
+			'_type' => 'classic:image',
+		);
+
+		$media_translate = $this->getMockBuilder( 'WPML_Page_Builders_Media_Translate' )
+		                        ->disableOriginalConstructor()->getMock();
+		$media_translate->method( 'translate_image_url' )
+		                ->with( $original_url, $target_lang, $source_lang )
+		                ->willReturn( $translated_url );
+
+		$subject = new WPML_Cornerstone_Media_Node_Classic_Image( $media_translate );
+
+		$this->assertEquals( $expected_settings, $subject->translate( $settings, $target_lang, $source_lang ) );
+	}
+}

--- a/tests/phpunit/tests/media/modules/test-wpml-cornerstone-media-node-classic-promo.php
+++ b/tests/phpunit/tests/media/modules/test-wpml-cornerstone-media-node-classic-promo.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * @group media
+ */
+class Test_WPML_Cornerstone_Media_Node_Classic_Promo extends OTGS_TestCase {
+
+	/**
+	 * @test
+	 */
+	public function it_should_translate() {
+		$source_lang    = 'en';
+		$target_lang    = 'fr';
+		$original_url   = 'http://example.org/dog.jpg';
+		$translated_url = 'http://example.org/chien.jpg';
+
+		$settings = array(
+			'foo'   => 'bar',
+			'image' => $original_url,
+			'_type' => 'classic:promo',
+		);
+
+		$expected_settings = array(
+			'foo'   => 'bar',
+			'image' => $translated_url,
+			'_type' => 'classic:promo',
+		);
+
+		$media_translate = $this->getMockBuilder( 'WPML_Page_Builders_Media_Translate' )
+		                        ->disableOriginalConstructor()->getMock();
+		$media_translate->method( 'translate_image_url' )
+		                ->with( $original_url, $target_lang, $source_lang )
+		                ->willReturn( $translated_url );
+
+		$subject = new WPML_Cornerstone_Media_Node_Classic_Promo( $media_translate );
+
+		$this->assertEquals( $expected_settings, $subject->translate( $settings, $target_lang, $source_lang ) );
+	}
+}

--- a/tests/phpunit/tests/media/modules/test-wpml-cornerstone-media-node-image.php
+++ b/tests/phpunit/tests/media/modules/test-wpml-cornerstone-media-node-image.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * @group media
+ */
+class Test_WPML_Cornerstone_Media_Node_Image extends OTGS_TestCase {
+
+	/**
+	 * @test
+	 */
+	public function it_should_translate() {
+		$source_lang    = 'en';
+		$target_lang    = 'fr';
+		$original_url   = 'http://example.org/dog.jpg';
+		$translated_url = 'http://example.org/chien.jpg';
+
+		$settings = array(
+			'foo'       => 'bar',
+			'image_src' => $original_url,
+			'_type'     => 'image',
+		);
+
+		$expected_settings = array(
+			'foo'       => 'bar',
+			'image_src' => $translated_url,
+			'_type'     => 'image',
+		);
+
+		$media_translate = $this->getMockBuilder( 'WPML_Page_Builders_Media_Translate' )
+		                        ->disableOriginalConstructor()->getMock();
+		$media_translate->method( 'translate_image_url' )
+		                ->with( $original_url, $target_lang, $source_lang )
+		                ->willReturn( $translated_url );
+
+		$subject = new WPML_Cornerstone_Media_Node_Image( $media_translate );
+
+		$this->assertEquals( $expected_settings, $subject->translate( $settings, $target_lang, $source_lang ) );
+	}
+}

--- a/tests/phpunit/tests/media/test-wpml-cornerstone-media-hooks-factory.php
+++ b/tests/phpunit/tests/media/test-wpml-cornerstone-media-hooks-factory.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * @group media
+ */
+class Test_WPML_Cornerstone_Media_Hooks_Factory extends OTGS_TestCase {
+
+	/**
+	 * @test
+	 */
+	public function it_should_load_on_backend_and_frontend() {
+		$subject = new WPML_Cornerstone_Media_Hooks_Factory();
+		$this->assertInstanceOf( 'IWPML_Backend_Action_Loader', $subject );
+		$this->assertInstanceOf( 'IWPML_Frontend_Action_Loader', $subject );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_create_and_return_an_instance() {
+		$GLOBALS['sitepress'] = $this->getMockBuilder( 'SitePress' )->getMock();
+		\Mockery::mock( 'alias:WPML_Page_Builders_Media_Hooks' );
+		$subject = new WPML_Cornerstone_Media_Hooks_Factory();
+		$this->assertInstanceOf( 'WPML_Page_Builders_Media_Hooks', $subject->create() );
+	}
+}
+
+if ( ! interface_exists( 'IWPML_PB_Media_Update_Factory' ) ) {
+	interface IWPML_PB_Media_Update_Factory {}
+}

--- a/tests/phpunit/tests/media/test-wpml-cornerstone-media-node-provider.php
+++ b/tests/phpunit/tests/media/test-wpml-cornerstone-media-node-provider.php
@@ -1,0 +1,44 @@
+<?php
+
+/**
+ * @group media
+ */
+class Test_WPML_Cornerstone_Media_Node_Provider extends OTGS_TestCase {
+
+	/**
+	 * @test
+	 * @dataProvider dp_node_types
+	 *
+	 * @param string $type
+	 * @param string $class_name
+	 */
+	public function it_should_return_a_node_instance_and_cache_it( $type, $class_name ) {
+		$GLOBALS['sitepress'] = $this->getMockBuilder( 'SitePress' )->disableOriginalConstructor()->getMock();
+		$this->mock_external_classes();
+
+		$media_translate = $this->getMockBuilder( 'WPML_Page_Builders_Media_Translate' )
+		                        ->disableOriginalConstructor()->getMock();
+
+		$subject = new WPML_Cornerstone_Media_Node_Provider( $media_translate );
+
+		$this->assertInstanceOf( $class_name, $subject->get( $type ) );
+		$this->assertSame( $subject->get( $type ), $subject->get( $type ) );
+	}
+
+	public function dp_node_types() {
+		return array(
+			'image'                => array( 'image', 'WPML_Cornerstone_Media_Node_Image' ),
+			'classic:creative-cta' => array( 'classic:creative-cta', 'WPML_Cornerstone_Media_Node_Classic_Creative_CTA' ),
+			'classic:feature-box'  => array( 'classic:feature-box', 'WPML_Cornerstone_Media_Node_Classic_Feature_Box' ),
+			'classic:card'         => array( 'classic:card', 'WPML_Cornerstone_Media_Node_Classic_Card' ),
+			'classic:image'        => array( 'classic:image', 'WPML_Cornerstone_Media_Node_Classic_Image' ),
+			'classic:promo'        => array( 'classic:promo', 'WPML_Cornerstone_Media_Node_Classic_Promo' ),
+		);
+	}
+
+	private function mock_external_classes() {
+		$this->getMockBuilder( 'WPML_Translation_Element_Factory' )->getMock();
+		$this->getMockBuilder( 'WPML_Media_Image_Translate' )->getMock();
+		$this->getMockBuilder( 'WPML_Media_Attachment_By_URL_Factory' )->getMock();
+	}
+}

--- a/tests/phpunit/tests/media/test-wpml-cornerstone-media-nodes-iterator.php
+++ b/tests/phpunit/tests/media/test-wpml-cornerstone-media-nodes-iterator.php
@@ -1,0 +1,89 @@
+<?php
+
+/**
+ * @group media
+ */
+class Test_WPML_Cornerstone_Media_Nodes_Iterator extends OTGS_TestCase {
+
+	/**
+	 * @test
+	 */
+	public function it_should_translate() {
+		$lang        = 'fr';
+		$source_lang = 'en';
+
+		$image_data = array(
+			'src'   => 'http://example.org/dog.jpg',
+			'_type' => 'image',
+		);
+
+		$image_data_translated = array(
+			'src'   => 'http://example.org/chien.jpg',
+			'_type' => 'image',
+		);
+
+		$data = array(
+			array(
+				'foo'   => 'bar',
+				'_type' => 'column',
+				'_modules' => array(
+					array( 'unknown / not translated' ),
+					array(
+						'foo'   => 'bar',
+						'_type' => 'not-supported',
+					),
+					$image_data,
+				)
+			),
+		);
+
+		$expected_data = array(
+			array(
+				'foo'   => 'bar',
+				'_type' => 'column',
+				'_modules' => array(
+					array( 'unknown / not translated' ),
+					array(
+						'foo'   => 'bar',
+						'_type' => 'not-supported',
+					),
+					$image_data_translated
+				)
+			),
+		);
+
+		$node_image = $this->get_node();
+		$node_image->method( 'translate' )->with( $image_data, $lang, $source_lang )
+			->willReturn( $image_data_translated );
+
+		$node_provider = $this->get_node_provider();
+		$node_provider->method( 'get' )->willReturnMap(
+			array(
+				array( 'image', $node_image ),
+				array( 'not-supported', null ),
+			)
+		);
+
+		$subject = $this->get_subject( $node_provider );
+
+		$this->assertEquals( $expected_data, $subject->translate( $data, $lang, $source_lang ) );
+	}
+
+	private function get_subject( $node_provider ) {
+		return new WPML_Cornerstone_Media_Nodes_Iterator( $node_provider );
+	}
+
+	private function get_node_provider() {
+		return $this->getMockBuilder( 'WPML_Cornerstone_Media_Node_Provider' )
+			->setMethods( array( 'get' ) )->disableOriginalConstructor()->getMock();
+	}
+
+	private function get_node() {
+		return $this->getMockBuilder( 'WPML_Cornerstone_Media_Node' )
+		            ->setMethods( array( 'translate' ) )->disableOriginalConstructor()->getMock();
+	}
+}
+
+if ( ! interface_exists( 'IWPML_PB_Media_Nodes_Iterator' ) ) {
+	interface IWPML_PB_Media_Nodes_Iterator {}
+}

--- a/tests/phpunit/tests/media/test-wpml-cornerstone-update-media-factory.php
+++ b/tests/phpunit/tests/media/test-wpml-cornerstone-update-media-factory.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * @group media
+ */
+class Test_WPML_Cornerstone_Update_Media_Factory extends OTGS_TestCase {
+
+	public function setUp() {
+		parent::setUp();
+		\Mockery::mock( 'alias:WPML_Page_Builders_Update_Media' );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_implement_iwpml_pb_media_update_factory() {
+		$subject = new WPML_Cornerstone_Update_Media_Factory();
+		$this->assertInstanceOf( 'IWPML_PB_Media_Update_Factory', $subject );
+	}
+
+	/**
+	 * @test
+	 */
+	public function it_should_return_an_instance_of_page_builders_media_update() {
+		$this->getMockBuilder( 'WPML_Media_Usage_Factory' )->getMock();
+		$subject = new WPML_Cornerstone_Update_Media_Factory();
+		$this->assertInstanceOf( 'WPML_Page_Builders_Update_Media', $subject->create() );
+	}
+}
+
+if ( ! interface_exists( 'IWPML_PB_Media_Update_Factory' ) ) {
+	interface IWPML_PB_Media_Update_Factory {}
+}

--- a/tests/phpunit/tests/test-wpml-cornerstone-integration-factory.php
+++ b/tests/phpunit/tests/test-wpml-cornerstone-integration-factory.php
@@ -20,6 +20,7 @@ class Test_WPML_Cornerstone_Integration_Factory extends OTGS_TestCase {
 		\Mockery::mock( 'overload:WPML_String_Registration_Factory' )->shouldReceive( 'create' )->andReturn( $string_registration );
 		\Mockery::mock( 'overload:WPML_Action_Filter_Loader' )->shouldReceive( 'load' )->with( array(
 			'WPML_PB_Cornerstone_Handle_Custom_Fields_Factory',
+			'WPML_Cornerstone_Media_Hooks_Factory',
 		) );
 
 		$this->assertInstanceOf( 'WPML_Page_Builders_Integration', $subject->create() );


### PR DESCRIPTION
I initially created the media nodes for classic blocks and later I saw that the source of truth is the shortcode for it (even if we also have a proper node in the metadata). I decided to keep it because the shortcodes might be removed one day.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlmedia-547