### PR TITLE
Set the "card: anchor link" string as a LINK instead of a LINE

### DIFF
--- a/src/class-wpml-cornerstone-translatable-nodes.php
+++ b/src/class-wpml-cornerstone-translatable-nodes.php
@@ -197,7 +197,7 @@ class WPML_Cornerstone_Translatable_Nodes implements IWPML_Page_Builders_Transla
 					[
 						'field'       => 'anchor_href',
 						'type'        => __( 'Card: anchor link', 'sitepress' ),
-						'editor_type' => 'LINE',
+						'editor_type' => 'LINK',
 					],
 				],
 			],


### PR DESCRIPTION
The fix was suggested by @mardroid in https://github.com/OnTheGoSystems/wpml-page-builders-cornerstone/pull/15.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-7244