### PR TITLE
 Invalidate generated CSS when a translation is saved 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,6 +36,8 @@
         "otgs/unit-tests-framework": "~1.2.0",
         "wpml/page-builders": "dev-develop",
         "wpml/fp": "^0.1.2",
-        "wpml/collect": "dev-wpml-collect-rename"
+        "wpml/collect": "dev-wpml-collect-rename",
+        "composer/composer": "^1.10",
+        "wpml/wp": "dev-develop"
     }
 }

--- a/src/Styles/Hooks.php
+++ b/src/Styles/Hooks.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace WPML\PB\Cornerstone\Styles;
+
+use WPML\FP\Fns;
+use WPML\FP\Logic;
+use WPML\FP\Maybe;
+use WPML\LIB\WP\Post;
+
+class Hooks implements \IWPML_Backend_Action, \IWPML_Frontend_Action, \IWPML_DIC_Action {
+
+	const META_KEY = '_cs_generated_styles';
+
+	/** @var callable $shouldInvalidateStyle */
+	private $shouldInvalidateStyles;
+
+	/**
+	 * Hooks constructor.
+	 *
+	 * @param \WPML_PB_Last_Translation_Edit_Mode $lastEditMode
+	 * @param \WPML_Cornerstone_Data_Settings     $dataSettings
+	 */
+	public function __construct(
+		\WPML_PB_Last_Translation_Edit_Mode $lastEditMode,
+		\WPML_Cornerstone_Data_Settings $dataSettings
+	) {
+		$this->shouldInvalidateStyles = Logic::both( [ $dataSettings, 'is_handling_post' ], [ $lastEditMode, 'is_translation_editor' ] );
+	}
+
+
+	public function add_hooks() {
+		add_action( 'save_post', [ $this, 'invalidateStylesInTranslation' ] );
+	}
+
+	/**
+	 * @param int $postId
+	 */
+	public function invalidateStylesInTranslation( $postId ) {
+		Maybe::of( $postId )
+			->filter( $this->shouldInvalidateStyles )
+			->map( Post::deleteMeta( Fns::__, self::META_KEY ) );
+	}
+}

--- a/src/class-wpml-cornerstone-integration-factory.php
+++ b/src/class-wpml-cornerstone-integration-factory.php
@@ -11,6 +11,7 @@ class WPML_Cornerstone_Integration_Factory {
 				'WPML_PB_Cornerstone_Handle_Custom_Fields_Factory',
 				'WPML_Cornerstone_Media_Hooks_Factory',
 				\WPML\PB\Cornerstone\Config\Factory::class,
+				\WPML\PB\Cornerstone\Styles\Hooks::class,
 			]
 		);
 

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -37,3 +37,33 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 require_once __DIR__ . '/../../vendor/autoload.php';
+
+try {
+	if ( ! spl_autoload_register( 'autoload_tests_classes' ) ) {
+		echo 'Test classes cannot be loaded!';
+		exit( 1 );
+	}
+} catch ( Exception $e ) {
+	echo $e->getMessage();
+	exit( 1 );
+}
+
+function autoload_tests_classes( $class ) {
+	static $maps;
+
+	if ( ! $maps ) {
+		$dirs = [
+			__DIR__ . '/../../vendor/wpml/wp/tests/mocks',
+		];
+
+		$maps = [];
+		foreach ( $dirs as $dir ) {
+			$maps = array_merge( $maps, \Composer\Autoload\ClassMapGenerator::createMap( $dir ) );
+		}
+	}
+
+	if ( $maps && array_key_exists( $class, $maps ) ) {
+		/** @noinspection PhpIncludeInspection */
+		require_once $maps[ $class ];
+	}
+}

--- a/tests/phpunit/stub/action-loader-interfaces.php
+++ b/tests/phpunit/stub/action-loader-interfaces.php
@@ -1,0 +1,13 @@
+<?php
+
+interface IWPML_AJAX_Action_Loader {}
+
+interface IWPML_Backend_Action_Loader {}
+
+interface IWPML_Backend_Action {}
+
+interface IWPML_Frontend_Action_Loader {}
+
+interface IWPML_Frontend_Action {}
+
+interface IWPML_DIC_Action {}

--- a/tests/phpunit/stub/iwpml-ajax-action-loader.php
+++ b/tests/phpunit/stub/iwpml-ajax-action-loader.php
@@ -1,5 +1,0 @@
-<?php
-
-interface IWPML_AJAX_Action_Loader {
-
-}

--- a/tests/phpunit/stub/iwpml-backend-action-loader.php
+++ b/tests/phpunit/stub/iwpml-backend-action-loader.php
@@ -1,5 +1,0 @@
-<?php
-
-interface IWPML_Backend_Action_Loader {
-
-}

--- a/tests/phpunit/stub/iwpml-frontend-action-loader.php
+++ b/tests/phpunit/stub/iwpml-frontend-action-loader.php
@@ -1,5 +1,0 @@
-<?php
-
-interface IWPML_Frontend_Action_Loader {
-
-}

--- a/tests/phpunit/tests/Styles/TestHooks.php
+++ b/tests/phpunit/tests/Styles/TestHooks.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace WPML\PB\Cornerstone\Styles;
+
+use WPML\LIB\WP\Post;
+use WPML\LIB\WP\PostMock;
+
+/**
+ * @group styles
+ */
+class TestHooks extends \OTGS_TestCase {
+
+	use PostMock;
+
+	public function setUp() {
+		parent::setUp();
+		$this->setUpPostMock();
+	}
+
+	/**
+	 * @test
+	 */
+	public function itShouldAddHooks() {
+		$subject = $this->getSubject();
+
+		\WP_Mock::expectActionAdded( 'save_post', [ $subject, 'invalidateStylesInTranslation' ] );
+
+		$subject->add_hooks();
+	}
+
+	/**
+	 * @test
+	 * @dataProvider dpShouldNotInvalidateStyles
+	 *
+	 * @param bool $isHandlingPost
+	 * @param bool $isTranslationEditor
+	 */
+	public function itShouldNotInvalidateStyles( $isHandlingPost, $isTranslationEditor ) {
+		$postId    = 123;
+		$metaValue = 'Some generated CSS';
+
+		Post::updateMeta( $postId, Hooks::META_KEY, $metaValue );
+
+		$lastEditMode = $this->getLastEditMode( $postId, $isTranslationEditor );
+		$dataSettings = $this->getDataSettings( $postId, $isHandlingPost );
+		$subject      = $this->getSubject( $lastEditMode, $dataSettings );
+
+		$subject->invalidateStylesInTranslation( $postId );
+
+		$this->assertSame( $metaValue, Post::getMetaSingle( $postId, Hooks::META_KEY, true ) );
+	}
+
+	/**
+	 * @test
+	 */
+	public function itShouldInvalidateStyles() {
+		$postId    = 123;
+
+		Post::updateMeta( $postId, Hooks::META_KEY, 'Some generated CSS' );
+
+		$lastEditMode = $this->getLastEditMode( $postId, true );
+		$dataSettings = $this->getDataSettings( $postId, true );
+		$subject      = $this->getSubject( $lastEditMode, $dataSettings );
+
+		$subject->invalidateStylesInTranslation( $postId );
+
+		$this->assertfalse( Post::getMetaSingle( $postId, Hooks::META_KEY, true ) );
+	}
+
+	public function dpShouldNotInvalidateStyles() {
+		return [
+			'not handled and not translation editor' => [ false, false ],
+			'not handled'                            => [ false, true ],
+			'not translation editor'                 => [ true, false ],
+		];
+	}
+
+	private function getSubject( $lastEditMode = null, $dataSettings = null ) {
+		$lastEditMode = $lastEditMode ?: $this->getLastEditMode();
+		$dataSettings = $dataSettings ?: $this->getDataSettings();
+
+		return new Hooks( $lastEditMode, $dataSettings );
+	}
+
+	private function getLastEditMode( $postId = 0, $isTranslationEditor = false ) {
+		$lastEditMode = $this->getMockBuilder( '\WPML_PB_Last_Translation_Edit_Mode' )
+			->setMethods( [ 'is_translation_editor' ] )
+			->disableOriginalConstructor()->getMock();
+		$lastEditMode->method( 'is_translation_editor' )->with( $postId )->willReturn( $isTranslationEditor );
+
+		return $lastEditMode;
+	}
+
+	private function getDataSettings( $postId = 0, $isHandlingPost = false ) {
+		$dataSettings = $this->getMockBuilder( '\WPML_Cornerstone_Data_Settings' )
+			->setMethods( [ 'is_handling_post' ] )
+			->disableOriginalConstructor()->getMock();
+		$dataSettings->method( 'is_handling_post' )->with( $postId )->willReturn( $isHandlingPost );
+
+		return $dataSettings;
+	}
+}

--- a/tests/phpunit/tests/test-wpml-cornerstone-integration-factory.php
+++ b/tests/phpunit/tests/test-wpml-cornerstone-integration-factory.php
@@ -22,6 +22,7 @@ class Test_WPML_Cornerstone_Integration_Factory extends OTGS_TestCase {
 			'WPML_PB_Cornerstone_Handle_Custom_Fields_Factory',
 			'WPML_Cornerstone_Media_Hooks_Factory',
 			\WPML\PB\Cornerstone\Config\Factory::class,
+			\WPML\PB\Cornerstone\Styles\Hooks::class,
 		) );
 
 		$this->assertInstanceOf( 'WPML_Page_Builders_Integration', $subject->create() );


### PR DESCRIPTION
~~Tests are failing because I am waiting for https://git.onthegosystems.com/wpml-packages/wp/-/merge_requests/24 to be merged.~~

The actual fix is in the last commit https://github.com/OnTheGoSystems/wpml-page-builders-cornerstone/pull/21/commits/c69edc45f2ebb772061af79726036830e1704aab.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-6597