### PR TITLE
[Already reviewed]Implement string translation reuse feature

### DIFF
--- a/src/class-wpml-cornerstone-integration-factory.php
+++ b/src/class-wpml-cornerstone-integration-factory.php
@@ -1,5 +1,7 @@
 <?php
 
+use function WPML\Container\make;
+
 class WPML_Cornerstone_Integration_Factory {
 
 	const SLUG = 'cornerstone';
@@ -21,7 +23,13 @@ class WPML_Cornerstone_Integration_Factory {
 		$string_registration_factory = new WPML_String_Registration_Factory( $data_settings->get_pb_name() );
 		$string_registration         = $string_registration_factory->create();
 
-		$register_strings   = new WPML_Cornerstone_Register_Strings( $nodes, $data_settings, $string_registration );
+		$factory  = make( WPML_PB_Factory::class );
+		$strategy = make( WPML_PB_API_Hooks_Strategy::class, [ ':name' => $data_settings->get_pb_name() ] );
+		$strategy->set_factory( $factory );
+
+		$reuse_translation = make( WPML_PB_Reuse_Translations_By_Strategy::class, [ ':strategy' => $strategy ] );
+
+		$register_strings   = new WPML_Cornerstone_Register_Strings( $nodes, $data_settings, $string_registration, $reuse_translation );
 		$update_translation = new WPML_Cornerstone_Update_Translation( $nodes, $data_settings );
 
 		return new WPML_Page_Builders_Integration( $register_strings, $update_translation, $data_settings );

--- a/tests/phpunit/tests/test-wpml-cornerstone-integration-factory.php
+++ b/tests/phpunit/tests/test-wpml-cornerstone-integration-factory.php
@@ -11,6 +11,21 @@ class Test_WPML_Cornerstone_Integration_Factory extends OTGS_TestCase {
 	 * @test
 	 */
 	public function it_creates_instance_of_page_builders_integration() {
+		$factory = \Mockery::mock( WPML_PB_Factory::class );
+
+		$strategy = \Mockery::mock( WPML_PB_API_Hooks_Strategy::class );
+		$strategy->shouldReceive( 'set_factory' )->with( $factory );
+
+		\WP_Mock::userFunction( 'WPML\Container\make' )
+		        ->with( WPML_PB_Factory::class )
+		        ->andReturn( $factory );
+		\WP_Mock::userFunction( 'WPML\Container\make' )
+		        ->with( WPML_PB_API_Hooks_Strategy::class, [ ':name' => 'Cornerstone' ] )
+		        ->andReturn( $strategy );
+		\WP_Mock::userFunction( 'WPML\Container\make' )
+		        ->with( WPML_PB_Reuse_Translations_By_Strategy::class, [ ':strategy' => $strategy ] )
+		        ->andReturn( \Mockery::mock( WPML_PB_Reuse_Translations_By_Strategy::class ) );
+
 		$subject = new WPML_Cornerstone_Integration_Factory();
 
 		$string_registration = $this->getMockBuilder( 'WPML_PB_String_Registration' )


### PR DESCRIPTION
This is a requirement for the "translation auto-update" feature because
Cornerstone does not have a permanent ID for its modules and we are
creating one from the module hash.

If we change some style in a module, the ID changes and we can't
retrieve the matching strings.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-7551