### PR TITLE
Filter `wpml_pb_is_editing_translation_with_native_editor`

### DIFF
--- a/src/Hooks/Editor.php
+++ b/src/Hooks/Editor.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace WPML\PB\Cornerstone\Hooks;
+
+use WPML\FP\Obj;
+use WPML\FP\Str;
+use WPML\LIB\WP\Hooks;
+use function WPML\FP\spreadArgs;
+
+class Editor implements \IWPML_Frontend_Action {
+
+	public function add_hooks() {
+		Hooks::onFilter( 'wpml_pb_is_editing_translation_with_native_editor' )
+			->then( spreadArgs( function( $isTranslationWithNativeEditor ) {
+				return $isTranslationWithNativeEditor
+					|| Str::includes( 'themeco/data/save', Obj::prop( 'REQUEST_URI', $_SERVER ) ) ;
+			} ) );
+	}
+}

--- a/src/class-wpml-cornerstone-integration-factory.php
+++ b/src/class-wpml-cornerstone-integration-factory.php
@@ -14,6 +14,7 @@ class WPML_Cornerstone_Integration_Factory {
 				'WPML_Cornerstone_Media_Hooks_Factory',
 				\WPML\PB\Cornerstone\Config\Factory::class,
 				\WPML\PB\Cornerstone\Styles\Hooks::class,
+				\WPML\PB\Cornerstone\Hooks\Editor::class,
 			]
 		);
 

--- a/tests/phpunit/tests/Hooks/TestEditor.php
+++ b/tests/phpunit/tests/Hooks/TestEditor.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace WPML\PB\Cornerstone\Hooks;
+
+use WPML\LIB\WP\OnActionMock;
+
+/**
+ * @group hooks
+ * @group editor
+ */
+class TestEditor extends \OTGS_TestCase {
+
+	use OnActionMock;
+
+	public function setUp() {
+		parent::setUp();
+		$this->setUpOnAction();
+	}
+
+	public function tearDown() {
+		unset( $_SERVER['REQUEST_URI'] );
+		$this->tearDownOnAction();
+		parent::tearDown();
+	}
+
+	/**
+	 * @test
+	 */
+	public function itReturnsTrueIfAlreadyTranslatingWithNativeEditor() {
+		$subject = new Editor();
+		$subject->add_hooks();
+
+		$this->assertTrue( $this->runFilter( 'wpml_pb_is_editing_translation_with_native_editor', true ) );
+	}
+
+	/**
+	 * @test
+	 */
+	public function itReturnsTrueIfTranslatingWithCornerstoneNativeEditor() {
+		$_SERVER['REQUEST_URI'] = '/fr/wp-json/themeco/data/save?_locale=user';
+
+		$subject = new Editor();
+		$subject->add_hooks();
+
+		$this->assertTrue( $this->runFilter( 'wpml_pb_is_editing_translation_with_native_editor', false ) );
+	}
+}

--- a/tests/phpunit/tests/Styles/TestHooks.php
+++ b/tests/phpunit/tests/Styles/TestHooks.php
@@ -4,16 +4,19 @@ namespace WPML\PB\Cornerstone\Styles;
 
 use WPML\LIB\WP\Post;
 use WPML\LIB\WP\PostMock;
+use WPML\LIB\WP\WPDBMock;
 
 /**
  * @group styles
  */
 class TestHooks extends \OTGS_TestCase {
 
+	use WPDBMock;
 	use PostMock;
 
 	public function setUp() {
 		parent::setUp();
+		$this->setUpWPDBMock();
 		$this->setUpPostMock();
 	}
 
@@ -83,10 +86,10 @@ class TestHooks extends \OTGS_TestCase {
 	}
 
 	private function getLastEditMode( $postId = 0, $isTranslationEditor = false ) {
-		$lastEditMode = $this->getMockBuilder( '\WPML_PB_Last_Translation_Edit_Mode' )
-			->setMethods( [ 'is_translation_editor' ] )
-			->disableOriginalConstructor()->getMock();
-		$lastEditMode->method( 'is_translation_editor' )->with( $postId )->willReturn( $isTranslationEditor );
+		$lastEditMode = \Mockery::mock( \WPML_PB_Last_Translation_Edit_Mode::class );
+		$lastEditMode->shouldReceive( 'is_translation_editor' )
+			->with( $postId )
+			->andReturn( $isTranslationEditor );
 
 		return $lastEditMode;
 	}

--- a/tests/phpunit/tests/test-wpml-cornerstone-integration-factory.php
+++ b/tests/phpunit/tests/test-wpml-cornerstone-integration-factory.php
@@ -38,6 +38,7 @@ class Test_WPML_Cornerstone_Integration_Factory extends OTGS_TestCase {
 			'WPML_Cornerstone_Media_Hooks_Factory',
 			\WPML\PB\Cornerstone\Config\Factory::class,
 			\WPML\PB\Cornerstone\Styles\Hooks::class,
+			\WPML\PB\Cornerstone\Hooks\Editor::class,
 		) );
 
 		$this->assertInstanceOf( 'WPML_Page_Builders_Integration', $subject->create() );


### PR DESCRIPTION
Same issue as OnTheGoSystems/wpml-page-builders-elementor#149.

This will ensure we set the right `_last_translation_edit_mode` post
meta when a translation is edited with Cornerstone's editor.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-7656