### PR TITLE
Improve the way we flag is a translation has been edited with Cornerstone or not

### DIFF
--- a/src/Hooks/Editor.php
+++ b/src/Hooks/Editor.php
@@ -2,6 +2,8 @@
 
 namespace WPML\PB\Cornerstone\Hooks;
 
+use WPML\FP\Cast;
+use WPML\FP\Maybe;
 use WPML\FP\Obj;
 use WPML\FP\Str;
 use WPML\LIB\WP\Hooks;
@@ -10,10 +12,39 @@ use function WPML\FP\spreadArgs;
 class Editor implements \IWPML_Frontend_Action {
 
 	public function add_hooks() {
-		Hooks::onFilter( 'wpml_pb_is_editing_translation_with_native_editor' )
-			->then( spreadArgs( function( $isTranslationWithNativeEditor ) {
+		Hooks::onFilter( 'wpml_pb_is_editing_translation_with_native_editor', 10, 2 )
+			->then( spreadArgs( function( $isTranslationWithNativeEditor, $translatedPostId ) {
 				return $isTranslationWithNativeEditor
-					|| Str::includes( 'themeco/data/save', Obj::prop( 'REQUEST_URI', $_SERVER ) ) ;
+					|| (
+							Str::includes( 'themeco/data/save', Obj::prop( 'REQUEST_URI', $_SERVER ) )
+							&& self::getEditedId() === $translatedPostId
+				       );
 			} ) );
+	}
+
+	/**
+	 * @return int|null
+	 */
+	private static function getEditedId() {
+		/**
+		 * @see \Cornerstone_Routing::process_params
+		 * $decodeCornerstoneData :: string -> array
+		 */
+		$decodeCornerstoneData = function( $data ) {
+			$request = Obj::prop( 'request', $data );
+
+			if ( Obj::prop( 'gzip', $data ) ) {
+				return (array) json_decode( gzdecode( base64_decode( $request, true ) ), true );
+			}
+
+			return (array) $request;
+		};
+
+		return Maybe::fromNullable( \WP_REST_Server::get_raw_data() )
+			->map( 'json_decode' )
+			->map( $decodeCornerstoneData )
+			->map( Obj::path( [ 'requests', 'builder', 'id' ] ) )
+			->map( Cast::toInt() )
+			->getOrElse( null );
 	}
 }

--- a/src/Styles/Hooks.php
+++ b/src/Styles/Hooks.php
@@ -9,7 +9,8 @@ use WPML\LIB\WP\Post;
 
 class Hooks implements \IWPML_Backend_Action, \IWPML_Frontend_Action, \IWPML_DIC_Action {
 
-	const META_KEY = '_cs_generated_styles';
+	const META_KEY_OLD = '_cs_generated_styles';
+	const META_KEY_V6 = '_cs_generated_tss';
 
 	/** @var callable $shouldInvalidateStyle */
 	private $shouldInvalidateStyles;
@@ -38,6 +39,7 @@ class Hooks implements \IWPML_Backend_Action, \IWPML_Frontend_Action, \IWPML_DIC
 	public function invalidateStylesInTranslation( $postId ) {
 		Maybe::of( $postId )
 			->filter( $this->shouldInvalidateStyles )
-			->map( Post::deleteMeta( Fns::__, self::META_KEY ) );
+			->map( Fns::tap( Post::deleteMeta( Fns::__, self::META_KEY_V6 ) ) )
+			->map( Fns::tap( Post::deleteMeta( Fns::__, self::META_KEY_OLD ) ) );
 	}
 }

--- a/tests/phpunit/bootstrap.php
+++ b/tests/phpunit/bootstrap.php
@@ -54,6 +54,7 @@ function autoload_tests_classes( $class ) {
 	if ( ! $maps ) {
 		$dirs = [
 			__DIR__ . '/../../vendor/wpml/wp/tests/mocks',
+			__DIR__ . '/stub',
 		];
 
 		$maps = [];

--- a/tests/phpunit/stub/WP_REST_Server.php
+++ b/tests/phpunit/stub/WP_REST_Server.php
@@ -1,0 +1,6 @@
+<?php
+
+class WP_REST_Server {
+
+	public static function get_raw_data() {}
+}

--- a/tests/phpunit/tests/Hooks/TestEditor.php
+++ b/tests/phpunit/tests/Hooks/TestEditor.php
@@ -2,6 +2,7 @@
 
 namespace WPML\PB\Cornerstone\Hooks;
 
+use tad\FunctionMocker\FunctionMocker;
 use WPML\LIB\WP\OnActionMock;
 
 /**
@@ -11,6 +12,9 @@ use WPML\LIB\WP\OnActionMock;
 class TestEditor extends \OTGS_TestCase {
 
 	use OnActionMock;
+
+	const ORIGINAL_POST_ID = 123;
+	const TRANSLATED_POST_ID = 456;
 
 	public function setUp() {
 		parent::setUp();
@@ -30,18 +34,118 @@ class TestEditor extends \OTGS_TestCase {
 		$subject = new Editor();
 		$subject->add_hooks();
 
-		$this->assertTrue( $this->runFilter( 'wpml_pb_is_editing_translation_with_native_editor', true ) );
+		$this->assertTrue( $this->runFilter( 'wpml_pb_is_editing_translation_with_native_editor', true, self::TRANSLATED_POST_ID ) );
+	}
+
+	/**
+	 * @test
+	 * @dataProvider dpValidRawRestData
+	 *
+	 * @param string $rawRestData
+	 */
+	public function itReturnsTrueIfTranslatingWithCornerstoneNativeEditor( $rawRestData ) {
+		$_SERVER['REQUEST_URI'] = '/fr/wp-json/themeco/data/save?_locale=user';
+
+		FunctionMocker::replace( 'WP_REST_Server::get_raw_data', $rawRestData );
+
+		$subject = new Editor();
+		$subject->add_hooks();
+
+		$this->assertTrue( $this->runFilter( 'wpml_pb_is_editing_translation_with_native_editor', false, self::TRANSLATED_POST_ID ) );
+	}
+
+	public function dpValidRawRestData() {
+		$data = [
+			'requests' => [
+				'builder' => [
+					'id' => (string) self::TRANSLATED_POST_ID,
+				],
+			],
+		];
+
+		return [
+			'with gzip'    => [
+				json_encode( [
+					'gzip'    => 1,
+					'request' => self::encodeGzipData( $data ),
+				] ),
+			],
+			'without gzip' => [
+				json_encode( [
+					'request' => $data,
+				] ),
+			],
+		];
 	}
 
 	/**
 	 * @test
 	 */
-	public function itReturnsTrueIfTranslatingWithCornerstoneNativeEditor() {
-		$_SERVER['REQUEST_URI'] = '/fr/wp-json/themeco/data/save?_locale=user';
+	public function itReturnsFalseIfEditingOriginalWithCornerstoneNativeEditor() {
+		$_SERVER['REQUEST_URI'] = '/wp-json/themeco/data/save?_locale=user';
+
+		$rawRestData = json_encode( [
+			'request' => [
+				'requests' => [
+					'builder' => [
+						'id' => (string) self::ORIGINAL_POST_ID,
+					],
+				],
+			],
+		] );
+
+		FunctionMocker::replace( 'WP_REST_Server::get_raw_data', $rawRestData );
 
 		$subject = new Editor();
 		$subject->add_hooks();
 
-		$this->assertTrue( $this->runFilter( 'wpml_pb_is_editing_translation_with_native_editor', false ) );
+		$this->assertFalse( $this->runFilter( 'wpml_pb_is_editing_translation_with_native_editor', false, self::TRANSLATED_POST_ID ) );
+	}
+
+	/**
+	 * @test
+	 * @dataProvider dpInvalidRawRestData
+	 *
+	 * @param string $rawRestData
+	 */
+	public function itReturnsFalseIfNOTTranslatingWithCornerstoneNativeEditor( $rawRestData ) {
+		$_SERVER['REQUEST_URI'] = '/fr/wp-json/themeco/data/save?_locale=user';
+
+		FunctionMocker::replace( 'WP_REST_Server::get_raw_data', $rawRestData );
+
+		$subject = new Editor();
+		$subject->add_hooks();
+
+		$this->assertFalse( $this->runFilter( 'wpml_pb_is_editing_translation_with_native_editor', false, self::TRANSLATED_POST_ID ) );
+	}
+
+	public function dpInvalidRawRestData() {
+		return [
+			'No ID provided'      => [
+				json_encode( [
+					'request' => [
+						'requests' => [
+							'builder' => [],
+						],
+					],
+				] ),
+			],
+			'No data in request'  => [
+				json_encode( [
+					'request' => [],
+				] ),
+			],
+			'Invalid json_decode' => [ '{"invalid JSON":...}' ],
+			'No raw REST data'    => [ null ],
+		];
+	}
+
+	/**
+	 * @param mixed $data
+	 *
+	 * @return string
+	 */
+	private static function encodeGzipData( $data ) {
+		return base64_encode( gzencode( json_encode( $data ) ) );
 	}
 }

--- a/tests/phpunit/tests/Styles/TestHooks.php
+++ b/tests/phpunit/tests/Styles/TestHooks.php
@@ -42,7 +42,8 @@ class TestHooks extends \OTGS_TestCase {
 		$postId    = 123;
 		$metaValue = 'Some generated CSS';
 
-		Post::updateMeta( $postId, Hooks::META_KEY, $metaValue );
+		Post::updateMeta( $postId, Hooks::META_KEY_OLD, $metaValue );
+		Post::updateMeta( $postId, Hooks::META_KEY_V6, $metaValue );
 
 		$lastEditMode = $this->getLastEditMode( $postId, $isTranslationEditor );
 		$dataSettings = $this->getDataSettings( $postId, $isHandlingPost );
@@ -50,7 +51,8 @@ class TestHooks extends \OTGS_TestCase {
 
 		$subject->invalidateStylesInTranslation( $postId );
 
-		$this->assertSame( $metaValue, Post::getMetaSingle( $postId, Hooks::META_KEY, true ) );
+		$this->assertSame( $metaValue, Post::getMetaSingle( $postId, Hooks::META_KEY_OLD, true ) );
+		$this->assertSame( $metaValue, Post::getMetaSingle( $postId, Hooks::META_KEY_V6, true ) );
 	}
 
 	/**
@@ -59,7 +61,8 @@ class TestHooks extends \OTGS_TestCase {
 	public function itShouldInvalidateStyles() {
 		$postId    = 123;
 
-		Post::updateMeta( $postId, Hooks::META_KEY, 'Some generated CSS' );
+		Post::updateMeta( $postId, Hooks::META_KEY_OLD, 'Some generated CSS' );
+		Post::updateMeta( $postId, Hooks::META_KEY_V6, 'Some generated CSS' );
 
 		$lastEditMode = $this->getLastEditMode( $postId, true );
 		$dataSettings = $this->getDataSettings( $postId, true );
@@ -67,7 +70,8 @@ class TestHooks extends \OTGS_TestCase {
 
 		$subject->invalidateStylesInTranslation( $postId );
 
-		$this->assertfalse( Post::getMetaSingle( $postId, Hooks::META_KEY, true ) );
+		$this->assertfalse( Post::getMetaSingle( $postId, Hooks::META_KEY_OLD, true ) );
+		$this->assertfalse( Post::getMetaSingle( $postId, Hooks::META_KEY_V6, true ) );
 	}
 
 	public function dpShouldNotInvalidateStyles() {


### PR DESCRIPTION
Before to run my manual tests, I have updated Cornerstone to v6 and noticed that styling were not properly applied.
I found out that their cached style post meta has changed. So I added an extra commit to fix this.

https://onthegosystems.myjetbrains.com/youtrack/issue/wpmlcore-8858